### PR TITLE
Remove unused function

### DIFF
--- a/papersolver.py
+++ b/papersolver.py
@@ -34,10 +34,6 @@ class Command:
         pass
 
 
-def execute_latex():
-    return True
-
-
 """
 @@@@@@@@@@@@@@@@@@
 @@ SEARCH TOOLS @@


### PR DESCRIPTION
## Summary
- delete `execute_latex` from `papersolver.py`
- confirm no references remain

## Testing
- `python -m py_compile papersolver.py`
