### PR TITLE
Fix Arxiv FULL_TEXT parsing and add tests

### DIFF
--- a/papersolver.py
+++ b/papersolver.py
@@ -75,7 +75,7 @@ class Arxiv(Command):
         full_text = extract_prompt(args[0], "FULL_TEXT").split("\n")
         if len(sum_text) == 0 and len(full_text) == 0: return False, None
         if len(sum_text) > 0: return True, ("SUMMARY", sum_text,)
-        if len(full_text) > 0: return True, ("FULL_TEXT", sum_text,)
+        if len(full_text) > 0: return True, ("FULL_TEXT", full_text,)
 
 
 """

--- a/tests/test_papersolver_parse.py
+++ b/tests/test_papersolver_parse.py
@@ -1,0 +1,41 @@
+import unittest
+import re
+from pathlib import Path
+
+class EmptyStr:
+    def split(self, sep=None):
+        return []
+
+def load_arxiv():
+    source = Path('papersolver.py').read_text()
+    match = re.search(r'class Arxiv\(Command\):(.*?)(?=class PaperReplace)', source, re.S)
+    code = match.group(0)
+    class Command:
+        pass
+    def extract_prompt(text, word):
+        pattern = rf"```{word}(.*?)```"
+        blocks = re.findall(pattern, text, re.DOTALL)
+        if not blocks:
+            return EmptyStr()
+        return "\n".join(blocks).strip()
+    namespace = {'Command': Command, 'extract_prompt': extract_prompt, 'EmptyStr': EmptyStr}
+    exec(code, namespace)
+    return namespace['Arxiv']
+
+class ParseCommandTest(unittest.TestCase):
+    def setUp(self):
+        Arxiv = load_arxiv()
+        self.arxiv = Arxiv.__new__(Arxiv)
+
+    def test_summary(self):
+        success, data = self.arxiv.parse_command('```SUMMARY\nquery\n```')
+        self.assertTrue(success)
+        self.assertEqual(data, ('SUMMARY', ['query']))
+
+    def test_full_text(self):
+        success, data = self.arxiv.parse_command('```FULL_TEXT\npaper123\n```')
+        self.assertTrue(success)
+        self.assertEqual(data, ('FULL_TEXT', ['paper123']))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct `FULL_TEXT` return value in `papersolver.Arxiv.parse_command`
- add a unittest verifying SUMMARY and FULL_TEXT parsing logic

## Testing
- `python -m unittest tests/test_papersolver_parse.py`