### PR TITLE
Add ai_lab_repo.py wrapper notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ Run the package entry point instead:
 `python -m ai_lab --yaml-location "experiment_configs/MATH_agentlab.yaml"`
 
 
+### `ai_lab_repo.py` moved
+
+The original entry script `ai_lab_repo.py` now lives inside the `ai_lab` package.
+Start the project with the module invocation instead:
+
+```bash
+python -m ai_lab --yaml-location "experiment_configs/MATH_agentlab.yaml"
+```
+
+For backward compatibility, a thin wrapper named `ai_lab_repo.py` remains at the
+repository root. It imports and executes `ai_lab.__main__` while printing a
+deprecation warning. This wrapper will be removed after **July&nbsp;2025**.
+
+
 ### Co-Pilot mode
 
 To run Agent Laboratory in copilot mode, simply set the copilot-mode flag in your yaml config to `"true"`

--- a/ai_lab_repo.py
+++ b/ai_lab_repo.py
@@ -1,0 +1,12 @@
+import warnings
+from ai_lab.__main__ import main
+
+warnings.warn(
+    "ai_lab_repo.py has moved to the ai_lab package. Use 'python -m ai_lab' instead. "
+    "This compatibility shim will be removed after July 2025.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a shim script `ai_lab_repo.py` that defers to `ai_lab.__main__`
- document the location change in `README.md`

## Testing
- `python ai_lab_repo.py -h` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*